### PR TITLE
feat(assignedsite): add OverMidnight per-site flag

### DIFF
--- a/Microting.TimePlanningBase/Infrastructure/Data/Entities/AssignedSite.cs
+++ b/Microting.TimePlanningBase/Infrastructure/Data/Entities/AssignedSite.cs
@@ -183,6 +183,7 @@ public class AssignedSite: PnBase
     public int DaysBackInTimeAllowedEditing { get; set; } = 2;
     public DateTime ResignedAtDate { get; set; }
     public bool UseOneMinuteIntervals { get; set; }
+    public bool OverMidnight { get; set; }
     public bool AllowAcceptOfPlannedHours { get; set; }
     public bool AllowEditOfRegistrations { get; set; }
     public bool AllowPersonalTimeRegistration { get; set; }

--- a/Microting.TimePlanningBase/Infrastructure/Data/Entities/AssignedSiteVersion.cs
+++ b/Microting.TimePlanningBase/Infrastructure/Data/Entities/AssignedSiteVersion.cs
@@ -184,6 +184,7 @@ public class AssignedSiteVersion: PnBase
     public int DaysBackInTimeAllowedEditing { get; set; } = 2;
     public DateTime ResignedAtDate { get; set; }
     public bool UseOneMinuteIntervals { get; set; }
+    public bool OverMidnight { get; set; }
     public bool AllowAcceptOfPlannedHours { get; set; }
     public bool AllowEditOfRegistrations { get; set; }
     public bool AllowPersonalTimeRegistration { get; set; }

--- a/Microting.TimePlanningBase/Migrations/20260619120000_AddOverMidnightToAssignedSite.Designer.cs
+++ b/Microting.TimePlanningBase/Migrations/20260619120000_AddOverMidnightToAssignedSite.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microting.TimePlanningBase.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using Microting.TimePlanningBase.Infrastructure.Data;
 namespace Microting.TimePlanningBase.Migrations
 {
     [DbContext(typeof(TimePlanningPnDbContext))]
-    partial class TimePlanningPnDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619120000_AddOverMidnightToAssignedSite")]
+    partial class AddOverMidnightToAssignedSite
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Microting.TimePlanningBase/Migrations/20260619120000_AddOverMidnightToAssignedSite.cs
+++ b/Microting.TimePlanningBase/Migrations/20260619120000_AddOverMidnightToAssignedSite.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Microting.TimePlanningBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOverMidnightToAssignedSite : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "OverMidnight",
+                table: "AssignedSiteVersions",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "OverMidnight",
+                table: "AssignedSites",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "OverMidnight", table: "AssignedSiteVersions");
+            migrationBuilder.DropColumn(name: "OverMidnight", table: "AssignedSites");
+        }
+    }
+}


### PR DESCRIPTION
Adds a per-site `OverMidnight` bool (default `false`) to the `AssignedSite` entity + its `AssignedSiteVersion`, with an EF migration adding the `tinyint(1)` column (default false) to both `AssignedSites` and `AssignedSiteVersions`, plus the model-snapshot/designer update.

Part 1 of the per-site OverMidnight feature (base → plugin → flutter-time). When false (the default), the flutter-time client will stop backfilling/splitting shifts across midnight (leaves an open shift hanging instead of auto-closing at 00:00) — the source of the over-midnight pileup/midnight-truncation corruption. The server only carries the flag.

Spec: flutter-time/docs/superpowers/specs/2026-06-17-over-midnight-per-site-flag-design.md

On merge this needs to publish a new Microting.TimePlanningBase NuGet version for the plugin (Phase B) to reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)