### PR TITLE
feat(schema): per-shift Pause{N}OverrideMinutes on PlanRegistration

### DIFF
--- a/Microting.TimePlanningBase/Infrastructure/Data/Entities/PlanRegistration.cs
+++ b/Microting.TimePlanningBase/Infrastructure/Data/Entities/PlanRegistration.cs
@@ -168,6 +168,14 @@ public class PlanRegistration : PnBase
     public int NettoHoursOverrideInSeconds { get; set; }
     public bool NettoHoursOverrideActive { get; set; }
 
+    // Per-shift authoritative total pause in MINUTES set by an admin/editor.
+    // null = no override (compute from recorded pause slots); non-null = authoritative total for that shift.
+    public int? Pause1OverrideMinutes { get; set; }
+    public int? Pause2OverrideMinutes { get; set; }
+    public int? Pause3OverrideMinutes { get; set; }
+    public int? Pause4OverrideMinutes { get; set; }
+    public int? Pause5OverrideMinutes { get; set; }
+
     // Faster lookups in db
     public bool IsSaturday { get; set; }
     public bool IsSunday { get; set; }

--- a/Microting.TimePlanningBase/Infrastructure/Data/Entities/PlanRegistrationVersion.cs
+++ b/Microting.TimePlanningBase/Infrastructure/Data/Entities/PlanRegistrationVersion.cs
@@ -168,6 +168,14 @@ public class PlanRegistrationVersion : PnBase
     public int NettoHoursOverrideInSeconds { get; set; }
     public bool NettoHoursOverrideActive { get; set; }
 
+    // Per-shift authoritative total pause in MINUTES set by an admin/editor.
+    // null = no override (compute from recorded pause slots); non-null = authoritative total for that shift.
+    public int? Pause1OverrideMinutes { get; set; }
+    public int? Pause2OverrideMinutes { get; set; }
+    public int? Pause3OverrideMinutes { get; set; }
+    public int? Pause4OverrideMinutes { get; set; }
+    public int? Pause5OverrideMinutes { get; set; }
+
     // Faster lookups in db
     public bool IsSaturday { get; set; }
     public bool IsSunday { get; set; }

--- a/Microting.TimePlanningBase/Migrations/20260625095024_AddPauseOverrideMinutesToPlanRegistration.Designer.cs
+++ b/Microting.TimePlanningBase/Migrations/20260625095024_AddPauseOverrideMinutesToPlanRegistration.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microting.TimePlanningBase.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using Microting.TimePlanningBase.Infrastructure.Data;
 namespace Microting.TimePlanningBase.Migrations
 {
     [DbContext(typeof(TimePlanningPnDbContext))]
-    partial class TimePlanningPnDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260625095024_AddPauseOverrideMinutesToPlanRegistration")]
+    partial class AddPauseOverrideMinutesToPlanRegistration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Microting.TimePlanningBase/Migrations/20260625095024_AddPauseOverrideMinutesToPlanRegistration.cs
+++ b/Microting.TimePlanningBase/Migrations/20260625095024_AddPauseOverrideMinutesToPlanRegistration.cs
@@ -1,0 +1,118 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Microting.TimePlanningBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPauseOverrideMinutesToPlanRegistration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Pause1OverrideMinutes",
+                table: "PlanRegistrationVersions",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Pause2OverrideMinutes",
+                table: "PlanRegistrationVersions",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Pause3OverrideMinutes",
+                table: "PlanRegistrationVersions",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Pause4OverrideMinutes",
+                table: "PlanRegistrationVersions",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Pause5OverrideMinutes",
+                table: "PlanRegistrationVersions",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Pause1OverrideMinutes",
+                table: "PlanRegistrations",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Pause2OverrideMinutes",
+                table: "PlanRegistrations",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Pause3OverrideMinutes",
+                table: "PlanRegistrations",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Pause4OverrideMinutes",
+                table: "PlanRegistrations",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Pause5OverrideMinutes",
+                table: "PlanRegistrations",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Pause1OverrideMinutes",
+                table: "PlanRegistrationVersions");
+
+            migrationBuilder.DropColumn(
+                name: "Pause2OverrideMinutes",
+                table: "PlanRegistrationVersions");
+
+            migrationBuilder.DropColumn(
+                name: "Pause3OverrideMinutes",
+                table: "PlanRegistrationVersions");
+
+            migrationBuilder.DropColumn(
+                name: "Pause4OverrideMinutes",
+                table: "PlanRegistrationVersions");
+
+            migrationBuilder.DropColumn(
+                name: "Pause5OverrideMinutes",
+                table: "PlanRegistrationVersions");
+
+            migrationBuilder.DropColumn(
+                name: "Pause1OverrideMinutes",
+                table: "PlanRegistrations");
+
+            migrationBuilder.DropColumn(
+                name: "Pause2OverrideMinutes",
+                table: "PlanRegistrations");
+
+            migrationBuilder.DropColumn(
+                name: "Pause3OverrideMinutes",
+                table: "PlanRegistrations");
+
+            migrationBuilder.DropColumn(
+                name: "Pause4OverrideMinutes",
+                table: "PlanRegistrations");
+
+            migrationBuilder.DropColumn(
+                name: "Pause5OverrideMinutes",
+                table: "PlanRegistrations");
+        }
+    }
+}


### PR DESCRIPTION
Adds nullable `int? Pause1OverrideMinutes`..`Pause5OverrideMinutes` to `PlanRegistration` and `PlanRegistrationVersion`, with EF migration `AddPauseOverrideMinutesToPlanRegistration` (10 nullable columns across both tables).

`null` = compute pause from recorded slots (current behavior); non-null = authoritative manual/admin override for that shift's total pause — the worker's recorded pause start/stops stay intact for documentation.

Consumed by the timeplanning plugin so web + the (unchanged) mobile app can edit the total pause non-destructively. Reviewed (correctness + simplification), build green.

Tag `v10.0.53` after merge to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)