### PR TITLE
feat(schema): RegisteredUnderOneMinuteIntervals write-time mode marker

### DIFF
--- a/Microting.TimePlanningBase/Infrastructure/Data/Entities/PlanRegistration.cs
+++ b/Microting.TimePlanningBase/Infrastructure/Data/Entities/PlanRegistration.cs
@@ -225,6 +225,15 @@ public class PlanRegistration : PnBase
     public double? ExtraOvertimeHours { get; set; }
     public int? ExtraOvertimeHoursInSeconds { get; set; }
 
+    /// <summary>
+    /// Write-time mode marker stamped by every plugin write path from the site's
+    /// then-current <c>AssignedSite.UseOneMinuteIntervals</c>. Governs how this row's
+    /// registrations are displayed and calculated (exact stamps vs 5-minute ticks).
+    /// null = legacy row written before the marker existed; mode is unknown and must
+    /// be resolved via the version-timeline fallback.
+    /// </summary>
+    public bool? RegisteredUnderOneMinuteIntervals { get; set; }
+
     public PlanRegistration()
     {
         int minute = 0;

--- a/Microting.TimePlanningBase/Infrastructure/Data/Entities/PlanRegistrationVersion.cs
+++ b/Microting.TimePlanningBase/Infrastructure/Data/Entities/PlanRegistrationVersion.cs
@@ -224,4 +224,13 @@ public class PlanRegistrationVersion : PnBase
 
     public double? ExtraOvertimeHours { get; set; }
     public int? ExtraOvertimeHoursInSeconds { get; set; }
+
+    /// <summary>
+    /// Write-time mode marker stamped by every plugin write path from the site's
+    /// then-current <c>AssignedSite.UseOneMinuteIntervals</c>. Governs how this row's
+    /// registrations are displayed and calculated (exact stamps vs 5-minute ticks).
+    /// null = legacy row written before the marker existed; mode is unknown and must
+    /// be resolved via the version-timeline fallback.
+    /// </summary>
+    public bool? RegisteredUnderOneMinuteIntervals { get; set; }
 }

--- a/Microting.TimePlanningBase/Migrations/20260707173341_AddRegisteredUnderOneMinuteIntervalsToPlanRegistration.Designer.cs
+++ b/Microting.TimePlanningBase/Migrations/20260707173341_AddRegisteredUnderOneMinuteIntervalsToPlanRegistration.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microting.TimePlanningBase.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using Microting.TimePlanningBase.Infrastructure.Data;
 namespace Microting.TimePlanningBase.Migrations
 {
     [DbContext(typeof(TimePlanningPnDbContext))]
-    partial class TimePlanningPnDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260707173341_AddRegisteredUnderOneMinuteIntervalsToPlanRegistration")]
+    partial class AddRegisteredUnderOneMinuteIntervalsToPlanRegistration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Microting.TimePlanningBase/Migrations/20260707173341_AddRegisteredUnderOneMinuteIntervalsToPlanRegistration.cs
+++ b/Microting.TimePlanningBase/Migrations/20260707173341_AddRegisteredUnderOneMinuteIntervalsToPlanRegistration.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Microting.TimePlanningBase.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRegisteredUnderOneMinuteIntervalsToPlanRegistration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "RegisteredUnderOneMinuteIntervals",
+                table: "PlanRegistrationVersions",
+                type: "tinyint(1)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "RegisteredUnderOneMinuteIntervals",
+                table: "PlanRegistrations",
+                type: "tinyint(1)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RegisteredUnderOneMinuteIntervals",
+                table: "PlanRegistrationVersions");
+
+            migrationBuilder.DropColumn(
+                name: "RegisteredUnderOneMinuteIntervals",
+                table: "PlanRegistrations");
+        }
+    }
+}


### PR DESCRIPTION
## Purpose

Adds a nullable write-time mode marker `RegisteredUnderOneMinuteIntervals` to `PlanRegistration` (and its version entity). Every plugin write path stamps it from the site's then-current `UseOneMinuteIntervals`, so each row permanently records which representation mode it was written under:

- `true` — written under one-minute mode (punch-clock punches and admin exact edits alike): render/calculate from exact stamps.
- `false` — written under 5-minute mode: render its 5-minute ticks forever.
- `NULL` — legacy row from before the marker existed; mode is unknown and is resolved via the version-history timeline fallback.

This resolves the tick-parity vs admin-back-edit conflict found by the plugin's one-minute e2e suite — see microting/eform-angular-timeplanning-plugin#1637.

## Changes

- `PlanRegistration.RegisteredUnderOneMinuteIntervals` (`bool?`) + identical mirror on `PlanRegistrationVersion` (PnBase `MapVersion` copies by property name, so version rows pick it up automatically).
- EF Core migration `AddRegisteredUnderOneMinuteIntervalsToPlanRegistration` adds the nullable `tinyint(1)` column to **both** `PlanRegistrations` and `PlanRegistrationVersions`.

## Data safety

No column default and no data backfill: all existing rows stay `NULL` (legacy semantics). The migration is purely additive; `Down()` drops the two columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)